### PR TITLE
Additions to documentation and configs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 Ister Cloud Init Service
-=======================
+========================
 
 This little web application is intended to be a helper for standing up
 up n-node clusters of Clear Linux. It complements the Clear Linux
@@ -34,3 +34,28 @@ Standing up the web app (high level)
 # Test web-app
     curl localhost/icis/get_role/compute
 
+
+.. code-block:: console
+
+  mkdir -pv /var/www
+  mkdir -pv /var/log/uwsgi
+  chown httpd:httpd /var/log/uwsgi
+  cd /var/www/
+  git clone https://github.com/clearlinux/ister-cloud-init-svc
+  chown -R httpd:httpd /var/www
+  cd ister-cloud-init-svc
+  # Install python if you are on clear and don't have it already this bundle
+  # has it
+  swupd bundle-add os-core-dev
+  virtualenv .venv
+  . .venv/bin/activate
+  pip install -r requirements.txt
+  ln -s /var/www/ister-cloud-init-svc/icis_uwsgi.service \
+    /etc/systemd/system/icis_uwsgi.service
+  # If you are using nginx then obviously don't trash your current config, use
+  # this as a guide instead
+  cp /var/www/ister-cloud-init-svc/nginx.conf /etc/nginx/nginx.conf
+  systemctl daemon-reload
+  systemctl restart nginx icis_uwsgi
+  # Verify it reponds
+  curl http://localhost/icis/get_role/compute

--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@
 #
 
 from flask import Flask, abort, request, jsonify
-from settings import APP_STATIC
+from settings import APP_STATIC, SUBDIR
 import os
 import re
 
@@ -50,13 +50,13 @@ def get_config_data(mac_addr):
     return None
 
 
-@app.route('/')
+@app.route(SUBDIR + '/')
 def index():
     return 'Clear Cloud Init Service... is alive\n'
 
 
-@app.route('/get_config/<mac_addr>')
-@app.route('/get_config/')
+@app.route(SUBDIR + '/get_config/<mac_addr>')
+@app.route(SUBDIR + '/get_config/')
 def get_config(mac_addr=None):
     reply = None
     if mac_addr is None:
@@ -71,8 +71,8 @@ def get_config(mac_addr=None):
         abort(404)
 
 
-@app.route('/get_role/<role>')
-@app.route('/get_role/')
+@app.route(SUBDIR + '/get_role/<role>')
+@app.route(SUBDIR + '/get_role/')
 def get_role(role=None):
     reply = None
     if role is None:
@@ -89,5 +89,4 @@ def get_role(role=None):
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
-
+    app.run()

--- a/icis_uwsgi.service
+++ b/icis_uwsgi.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=ISTER uWSGI service
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/uwsgi --ini /var/www/ister-cloud-init-svc/icis_uwsgi.ini \
+  -H /var/www/ister-cloud-init-svc/.venv/
+Restart=always
+KillSignal=SIGQUIT
+NotifyAccess=all
+
+[Install]
+WantedBy=multi-user.target

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen       80;
+    server_name  hostname;
+    server_name_in_redirect off;
+    location / {
+        root   /var/www/pxe;
+        autoindex on;
+        index  index.html index.htm;
+    }
+    location /icis/static/ {
+        rewrite ^/icis/static(/.*)$ $1 break;
+        root /var/www/ister-cloud-init-svc/static/;
+    }
+    location /icis/ {
+        uwsgi_pass unix:///var/www/ister-cloud-init-svc/icis_uwsgi.sock;
+        include uwsgi_params;
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ Babel==2.1.1
 cffi==1.5.2
 chardet==2.3.0
 cryptography==1.2.3
-cupshelpers==1.0
 docutils==0.12
 Flask==0.10.1
 idna==2.0
@@ -13,8 +12,6 @@ itsdangerous==0.24
 Jinja2==2.8
 lazy-object-proxy==1.2.1
 livereload==2.4.0
-louis==2.6.5
-lxml==3.5.0
 MarkupSafe==0.23
 netifaces==0.10.4
 packaging==16.5
@@ -23,11 +20,8 @@ pep8==1.7.0
 ply==3.8
 pyasn1==0.1.9
 pycparser==2.14
-pycups==1.9.73
-pycurl==7.43.0
 pyelftools==0.23
 Pygments==2.0.2
-pygobject==3.18.2
 pylint==1.5.4
 pyOpenSSL==0.15.1
 pyparsing==2.1.0
@@ -41,7 +35,6 @@ snowballstemmer==1.2.0
 Sphinx==1.3.2
 sphinx-autobuild==0.5.2
 sphinx-rtd-theme==0.1.9
-team==1.0
 tornado==4.3
 urllib3==1.14
 urwid==1.3.1

--- a/settings.py
+++ b/settings.py
@@ -4,3 +4,4 @@ import os
 # APP_ROOT = application_top
 APP_ROOT = os.path.dirname(os.path.abspath(__file__))   
 APP_STATIC = os.path.join(APP_ROOT, 'static')
+SUBDIR = '/icis'

--- a/static/ister/ister.conf
+++ b/static/ister/ister.conf
@@ -1,1 +1,1 @@
-template=http://localhost:5000/static/ister/native-cloud.json
+template=http://192.168.1.1/icis/static/ister/native-cloud.json

--- a/static/ister/ister.json
+++ b/static/ister/ister.json
@@ -9,6 +9,6 @@
     "Version": 6580,
     "Bundles": ["kernel-native", "os-installer", "os-core-update", "os-core", "os-core-dev", "bootloader"],
     "PostNonChroot": ["./installation-image-post-update-version.py"],
-    "IsterCloudInitSvc": ["http://localhost:5000/"]
+    "IsterCloudInitSvc": ["http://192.168.1.1/icis/"]
 }
 

--- a/static/ister/native-cloud.json
+++ b/static/ister/native-cloud.json
@@ -9,6 +9,6 @@
     "Version": 6580,
     "Bundles": ["kernel-native", "os-core", "os-core-update", "os-cloudguest", "bootloader"],
     "PostNonChroot": ["./installation-image-post-update-version.py"],
-    "IsterCloudInitSvc": "http://localhost:5000/"
+    "IsterCloudInitSvc": "http://192.168.1.1/icis/"
 }
 


### PR DESCRIPTION
Removed unused modules from requirements.txt
  cupshelpers
  louis
  lxml
  pycups
  pycurl
  pygobject
  team

Added nginx.conf as an example of how to configure uwsgi with nginx.
This can be dropped in as a replacement for pxe nginx config file as
it includes both locations.

Added isic_uwsgi.service file to be placed in /etc/systemd/service/
to start the uwsgi app.

Added SUBDIR to settings.py so that the uwsgi app responds to
requests when it is served under the /icis subdirectory.

Signed-off-by: John Andersen john.s.andersen@intel.com
