### PR TITLE
Disable NetworkManager on server interfaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,11 @@ that are ready to be managed with Ansible.
 Getting Started
 ===============
 
-To get started, simply ``git clone https://github.com/clearlinux/ister-cloud-init-svc.git`` , 
+To get started, simply ``git clone https://github.com/clearlinux/ister-cloud-init-svc.git``, 
 configure parameters.conf to suit your system, and run ``install.sh``. 
-This will provision a PXE server and install ICIS with default configurations.
+This will provision a PXE server, install ICIS with default configurations,
+and disable NetworkManager for the internal/external interfaces set in
+parameters.conf which allows the systemd-networkd settings to take effect.
 
 The default configuration for provisioning a PXE server creates a router that
 performs network address translation for PXE clients.  Additional requirements

--- a/configure-ipxe.sh
+++ b/configure-ipxe.sh
@@ -78,7 +78,12 @@ Name=$internal_iface
 DHCP=no
 Address=$pxe_internal_ip/$pxe_subnet_bitmask
 EOF
-	
+	if systemctl is-active --quiet NetworkManager; then
+		echo "Disabling NetworkManager for $external_iface and $internal_iface"
+		nmcli device set $external_iface managed false
+		nmcli device set $internal_iface managed false
+	fi
+
 	systemctl restart systemd-networkd
 }
 


### PR DESCRIPTION
When NetworkManager is running, it conflicts with the sytemd-networkd
configurations. Disabling NetworkManager on the internal and external
interfaces allows systemd-networkd to properly configure them.

Fixes: #11

Signed-off-by: John Akre <john.w.akre@intel.com>