### PR TITLE
Replace ICIS references with CCIS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,17 @@
-ICIS: Ister Cloud Initialization Service
+CCIS: Clear Cloud Initialization Service
 #######################################
 
-ICIS is a service that `clr-installer`_ uses to automatically install an instance of
-Clear Linux.  It applies role-based coud-init configurations during the
+CCIS is a service that `clr-installer`_ uses to automatically install an instance of
+Clear Linux.  It applies role-based cloud-init configurations during the
 installation.  It can be used to stand up a cluster of Clear Linux instances
 that are ready to be managed with Ansible.
 
 Getting Started
 ===============
 
-To get started, simply ``git clone https://github.com/clearlinux/ister-cloud-init-svc.git``, 
+To get started, simply ``git clone https://github.com/clearlinux/clr-cloud-init-svc.git``,
 configure parameters.conf to suit your system, and run ``install.sh``. 
-This will provision a PXE server, install ICIS with default configurations,
+This will provision a PXE server, install CCIS with default configurations,
 and disable NetworkManager for the internal/external interfaces set in
 parameters.conf which allows the systemd-networkd settings to take effect.
 
@@ -21,7 +21,7 @@ that must be met to use the default configuration out of the box are outlined in
 the preparations section of the `network booting`_ documentation for Clear
 Linux.
 
-ICIS relies on cloud-init configurations to perform an automated installation of
+CCIS relies on cloud-init configurations to perform an automated installation of
 Clear Linux. These need to be changed to apply user-specific configurations.
 Instructions on how to change these are outlined in the `bulk provisioning`_
 documentation for Clear Linux.

--- a/configure-ipxe.sh
+++ b/configure-ipxe.sh
@@ -25,7 +25,7 @@ populate_ipxe_content() {
 	ln -sf $(ls $ipxe_root | grep 'org.clearlinux.*') $ipxe_root/linux
 	cat > $ipxe_root/ipxe_boot_script.txt << EOF
 #!ipxe
-kernel linux quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp rw initrd=initrd clri.descriptor=http://$pxe_internal_ip/$icis_app_name/static/clr-installer/cloud.yaml
+kernel linux quiet init=/usr/lib/systemd/systemd-bootchart initcall_debug tsc=reliable no_timer_check noreplace-smp rw initrd=initrd clri.descriptor=http://$pxe_internal_ip/$ccis_app_name/static/clr-installer/cloud.yaml
 initrd initrd
 boot
 EOF

--- a/install.sh
+++ b/install.sh
@@ -6,12 +6,12 @@ main() {
 	stop_web_services
 	$(dirname $0)/configure-ipxe.sh
 	if [ $? -eq 0 ]; then
-		populate_icis_content
+		populate_ccis_content
 		generate_web_configuration
 		start_web_services
 		return 0
 	else
-		echo 'ICIS not installed!!'
+		echo 'CCIS not installed!!'
 		return 1
 	fi
 }
@@ -23,28 +23,28 @@ install_dependencies() {
 
 stop_web_services() {
 	systemctl stop nginx
-	systemctl stop uwsgi@$icis_app_name.socket
-	systemctl disable uwsgi@$icis_app_name.service
+	systemctl stop uwsgi@$ccis_app_name.socket
+	systemctl disable uwsgi@$ccis_app_name.service
 }
 
-populate_icis_content() {
+populate_ccis_content() {
 	# Reference: http://uwsgi-docs.readthedocs.io/en/latest/Systemd.html#one-service-per-app-in-systemd
 	# Reference: https://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/
-	rm -rf $icis_root
-	mkdir -p $icis_root
-	cp -rf $(dirname ${0})/app/* $icis_root
-	local icis_venv_dir=$icis_root/env
-	virtualenv $icis_venv_dir
-	$icis_venv_dir/bin/pip install -r $(dirname ${0})/requirements.txt
+	rm -rf $ccis_root
+	mkdir -p $ccis_root
+	cp -rf $(dirname ${0})/app/* $ccis_root
+	local ccis_venv_dir=$ccis_root/env
+	virtualenv $ccis_venv_dir
+	$ccis_venv_dir/bin/pip install -r $(dirname ${0})/requirements.txt
 
 	mkdir -p $uwsgi_app_dir
-	cat > $uwsgi_app_dir/$icis_app_name.ini << EOF
+	cat > $uwsgi_app_dir/$ccis_app_name.ini << EOF
 [uwsgi]
 # App configurations
 module = app
 callable = app
-chdir = $icis_root
-home = $icis_venv_dir
+chdir = $ccis_root
+home = $ccis_venv_dir
 
 # Init system configurations
 master = true
@@ -67,12 +67,12 @@ server {
 		root $ipxe_root;
 		autoindex on;
 	}
-	location /$icis_app_name/static/ {
-		root $icis_root/static;
-		rewrite ^/$icis_app_name/static(/.*)$ \$1 break;
+	location /$ccis_app_name/static/ {
+		root $ccis_root/static;
+		rewrite ^/$ccis_app_name/static(/.*)$ \$1 break;
 	}
-	location /$icis_app_name/ {
-		uwsgi_pass unix://$uwsgi_socket_dir/$icis_app_name.sock;
+	location /$ccis_app_name/ {
+		uwsgi_pass unix://$uwsgi_socket_dir/$ccis_app_name.sock;
 		include uwsgi_params;
 	}
 }
@@ -80,9 +80,9 @@ EOF
 }
 
 start_web_services() {
-	systemctl enable uwsgi@$icis_app_name.service
-	systemctl enable uwsgi@$icis_app_name.socket
-	systemctl restart uwsgi@$icis_app_name.socket
+	systemctl enable uwsgi@$ccis_app_name.service
+	systemctl enable uwsgi@$ccis_app_name.socket
+	systemctl restart uwsgi@$ccis_app_name.socket
 	systemctl enable nginx
 	systemctl restart nginx
 }

--- a/parameters.conf
+++ b/parameters.conf
@@ -1,11 +1,11 @@
 #!/bin/bash
 uwsgi_app_dir=/usr/share/uwsgi
 uwsgi_socket_dir=/run/uwsgi
-icis_app_name=icis
+ccis_app_name=ccis
 
 web_root=/var/www
 ipxe_root=$web_root/ipxe
-icis_root=$web_root/$icis_app_name
+ccis_root=$web_root/$ccis_app_name
 tftp_root=/srv/tftp
 
 external_iface=eno1


### PR DESCRIPTION
After removal of ister, the project was rebranded as clr-cloud-init-svc