### PR TITLE
python static library changed bundles

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ main() {
 }
 
 install_dependencies() {
-	swupd bundle-add pxe-server python-basic-dev
+	swupd bundle-add pxe-server python-basic-dev python3-basic-static
 	pip install uwsgi
 }
 


### PR DESCRIPTION
When installing uWSGI with pip, we get a failure as the static python library was removed from the bundle `python-basic-dev` and placed in `python3-basic-static`.

`    gcc: error: /usr/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a: No such file or directory`

